### PR TITLE
More variations + refactoring

### DIFF
--- a/bench/beatwc.exs
+++ b/bench/beatwc.exs
@@ -2,49 +2,67 @@ defmodule BenchBeatwc do
   use Benchfella
 
   @data_files ["100","1000","10000","100000","1000000"]
-  
-  for chunk <- @data_files do 
-   	@chunk chunk 
-    bench "wc_l file with #{@chunk} lines" do
-      Beatwc.wc_l("./bench/data/#{@chunk}") 
+
+  setup_all do
+    Beatwc.init()
+  end
+
+  for chunk <- @data_files do
+   	@chunk chunk
+    bench "#{@chunk} lines, whole file, `wc -l`" do
+      Beatwc.wc_l("./bench/data/#{@chunk}", bench_context)
     end
-  end 
 
-  for chunk <- @data_files do 
-    @chunk chunk 
-    bench "naive file with #{@chunk} lines" do
-      Beatwc.naive("./bench/data/#{@chunk}") 
+    bench "#{@chunk} lines, line-delimited IO, serial" do
+      Beatwc.naive("./bench/data/#{@chunk}", bench_context)
     end
-  end 
 
-  for chunk <- @data_files do 
-    @chunk chunk 
-    bench "slurp file with #{@chunk} lines" do
-      Beatwc.slurp("./bench/data/#{@chunk}") 
+    bench "#{@chunk} lines, line-delimited IO, Flow, partitioned" do
+       Beatwc.naive_flow("./bench/data/#{@chunk}", bench_context)
     end
-  end 
 
- for chunk <- @data_files do 
-    @chunk chunk 
-    bench "allnifs file with #{@chunk} lines" do
-      Beatwc.allnifs("./bench/data/#{@chunk}") 
+    bench "#{@chunk} lines, line-delimited IO, Flow, single-stage" do
+       Beatwc.minimized_naive_flow("./bench/data/#{@chunk}", bench_context)
     end
-  end 
 
-  for chunk <- @data_files do 
-    @chunk chunk 
-    bench "chunkynifs file with #{@chunk} lines" do
-      Beatwc.chunkynifs("./bench/data/#{@chunk}") 
+    bench "#{@chunk} lines, whole file, :binary.replace/4" do
+      Beatwc.slurp("./bench/data/#{@chunk}", bench_context)
     end
-  end 
 
-  for chunk <- @data_files do 
-    @chunk chunk 
-    bench "parallel file with #{@chunk} lines" do
-       Beatwc.parallel("./bench/data/#{@chunk}") 
+    bench "#{@chunk} lines, whole file, :binary.matches/2" do
+      Beatwc.allnifs("./bench/data/#{@chunk}", bench_context)
     end
-  end 
 
+    bench "#{@chunk} lines, whole file, line-delimited StringIO, serial" do
+      Beatwc.naive_stringio("./bench/data/#{@chunk}", bench_context)
+    end
 
+    bench "#{@chunk} lines, chunked IO, serial, :binary.matches/2" do
+      Beatwc.chunkynifs("./bench/data/#{@chunk}", bench_context)
+    end
 
+    bench "#{@chunk} lines, whole file, chunked StringIO, :binary.matches/2" do
+      Beatwc.chunkynifs_on_stringio("./bench/data/#{@chunk}", bench_context)
+    end
+
+    bench "#{@chunk} lines, chunked IO, async-await, :binary.matches/2" do
+       Beatwc.async_await("./bench/data/#{@chunk}", bench_context)
+    end
+
+    bench "#{@chunk} lines, chunked IO, scatter+gather, :binary.matches/2" do
+       Beatwc.scatter_gather("./bench/data/#{@chunk}", bench_context)
+    end
+
+    bench "#{@chunk} lines, chunked IO, Task.async_stream, :binary.matches/2" do
+       Beatwc.async_stream("./bench/data/#{@chunk}", bench_context)
+    end
+
+    bench "#{@chunk} lines, chunked IO, Flow, partitioned, :binary.matches/2" do
+       Beatwc.chunky_flow("./bench/data/#{@chunk}", bench_context)
+    end
+
+    bench "#{@chunk} lines, chunked IO, Flow, single-stage, :binary.matches/2" do
+       Beatwc.minimized_chunky_flow("./bench/data/#{@chunk}", bench_context)
+    end
+  end
 end

--- a/lib/beatwc.ex
+++ b/lib/beatwc.ex
@@ -9,46 +9,116 @@ defmodule Beatwc do
   @pchunk_size 131072
   @chunk_size 32768
 
-  def wc_l(path) do
-    {result, 0} = System.cmd("wc",["-l", path])
-    result
-    |> String.split
-    |> List.first
-    |> String.to_integer
+  def init do
+    {:ok, :binary.compile_pattern(<<"\n">>)}
   end
 
-  def naive(path) do
-    path |> File.stream! |> Enum.count
+
+  def wc_l(path, _context \\ nil) do
+    {result, 0} = System.cmd("wc",["-l", path])
+
+    result
+    |> String.split()
+    |> List.first()
+    |> String.to_integer()
+  end
+
+  def naive(path, _context \\ nil) do
+    File.stream!(path)
+    |> Enum.count()
+  end
+
+  def naive_stringio(path, _context \\ nil) do
+    {:ok, stringio_pid} = StringIO.open(File.read!(path))
+
+    IO.binstream(stringio_pid, :line)
+    |> Enum.count
+  end
+
+  def naive_flow(path, _context \\ nil) do
+    File.stream!(path)
+    |> Flow.from_enumerable()
+    |> Flow.map(fn _ln -> 1 end)
+    |> Flow.partition()
+    |> Flow.reduce(fn -> [0] end, fn num, [acc] -> [num + acc] end)
+    |> Enum.sum()
+  end
+
+  def minimized_naive_flow(path, _context \\ nil) do
+    File.stream!(path)
+    |> Flow.from_enumerable()
+    |> Flow.map(fn _ln -> 1 end)
+    |> Flow.reduce(fn -> [0] end, fn num, [acc] -> [num + acc] end)
+    |> Enum.sum()
+  end
+
+  def chunky_flow(path, search_pat, chunksize \\ @pchunk_size) do
+    File.stream!(path, [], chunksize)
+    |> Flow.from_enumerable()
+    |> Flow.map(&count(&1, search_pat))
+    |> Flow.partition()
+    |> Flow.reduce(fn -> [0] end, fn num, [acc] -> [num + acc] end)
+    |> Enum.sum()
+  end
+
+  def minimized_chunky_flow(path, search_pat, chunksize \\ @pchunk_size) do
+    File.stream!(path, [], chunksize)
+    |> Flow.from_enumerable()
+    |> Flow.map(&count(&1, search_pat))
+    |> Flow.reduce(fn -> [0] end, fn num, [acc] -> [num + acc] end)
+    |> Enum.sum()
   end
 
   # The :binary functions split and replace are not nifs.
-  def slurp(path) do
+  def slurp(path, search_pat) do
     bin = File.read!(path)
-    search = :binary.compile_pattern(<<"\n">>)
-    new_bin = :binary.replace(bin,search,<<"">>,[:global])
+    new_bin = :binary.replace(bin, search_pat, <<"">>, [:global])
     :erlang.byte_size(bin) - :erlang.byte_size(new_bin)
   end
 
   # using the count function slows it down by 3 mu secs.
-  def allnifs(path) do
+  def allnifs(path, search_pat) do
     binary = File.read!(path)
-    search = :binary.compile_pattern(<<"\n">>)
-    :erlang.length(:binary.matches(binary, search))
+    :erlang.length(:binary.matches(binary, search_pat))
   end
 
-  def chunkynifs(path, chunksize \\ @chunk_size) do
+  def chunkynifs(path, search_pat, chunksize \\ @chunk_size) do
     File.stream!(path, [], chunksize)
-    |> Enum.reduce(0, fn(chunk, total) -> total + count(chunk) end)
+    |> Enum.reduce(0, fn(chunk, total) -> total + count(chunk, search_pat) end)
   end
 
-  def parallel(path, chunksize \\ @pchunk_size) do
+  def chunkynifs_on_stringio(path, search_pat, chunksize \\ @pchunk_size) do
+    {:ok, stringio_pid} = StringIO.open(File.read!(path))
+
+    IO.binstream(stringio_pid, chunksize)
+    |> Enum.reduce(0, fn(chunk, total) -> total + count(chunk, search_pat) end)
+  end
+
+  def scatter_gather(path, search_pat, chunksize \\ @pchunk_size) do
     File.stream!(path,[], chunksize)
-    |> EnumP.scatter(fn(chunk) -> count(chunk) end) |> EnumP.gather(0, fn(acc, result) -> result + acc end)
+    |> EnumP.scatter(fn(chunk) -> count(chunk, search_pat) end)
+    |> EnumP.gather(0, fn(acc, result) -> result + acc end)
   end
 
-  defp count(binary) do
-    search = :binary.compile_pattern(<<"\n">>)
-    :erlang.length(:binary.matches(binary, search))
+  def async_await(path, search_pat, chunksize \\ @pchunk_size) do
+    File.stream!(path, [], chunksize)
+    |> Enum.map(fn chunk ->
+      Task.async(fn -> count(chunk, search_pat) end)
+    end)
+    |> Enum.reduce(0, fn task, acc ->
+      acc + Task.await(task)
+    end)
   end
 
+  def async_stream(path, search_pat, chunksize \\ @pchunk_size) do
+    File.stream!(path, [], chunksize)
+    |> Task.async_stream(&count(&1, search_pat))
+    |> Enum.reduce(0, fn {:ok, num}, acc -> num + acc end)
+  end
+
+  defp count(binary, search_pat) do
+    :erlang.length(:binary.matches(binary, search_pat))
+  end
+
+  @compile {:inline, [count: 2]}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,9 @@ defmodule Beatwc.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:benchfella, git: "https://github.com/alco/benchfella.git"}]
+    [
+      {:flow, "~> 0.14.0"},
+      {:benchfella, git: "https://github.com/alco/benchfella.git"}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,5 @@
-%{"benchfella": {:hex, :benchfella, "0.2.1"}}
+%{
+  "benchfella": {:git, "https://github.com/alco/benchfella.git", "d4546fe801ca668794cf4e87b7f75825d6eb4239", []},
+  "flow": {:hex, :flow, "0.14.0", "a84a4afc8559e3eb9c3b73c7dd0b348817405f3208bb1a42cfea69a83ec17f35", [:mix], [{:gen_stage, "~> 0.14.0", [hex: :gen_stage, repo: "hexpm", optional: false]}], "hexpm"},
+  "gen_stage": {:hex, :gen_stage, "0.14.0", "65ae78509f85b59d360690ce3378d5096c3130a0694bab95b0c4ae66f3008fad", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
* Refactored / restructured bench DSL file to reduce code size
* Lifted `:binary.compile_pattern` calls out of the test cases, putting it into Benchfella's `setup_all` hook
* Added benchmark variants for a number of additional methods of counting lines in a file, including using `StringIO` and using `Flow` (which means `:flow` is now a dependency)
* Renamed the benchmark variants to be more descriptive and uniform for comparability